### PR TITLE
Add pregame and ingame boxscore to game threads

### DIFF
--- a/cbbBot.py
+++ b/cbbBot.py
@@ -42,7 +42,7 @@ def get_info(game_id):
     return [away_rank, away_team, away_record, home_rank, home_team, home_record, venue, city, state, network, start_time, away_flair, home_flair, game_clock, away_score, home_score]
 
 def make_thread(game_id, game_info, comment_stream_link = ''):
-    (away_rank, away_team, away_record, home_rank, home_team, home_record, venue, city, state, network, start_time, away_flair, home_flair, game_clock, away_score, home_score) = game_info
+    (away_rank, away_team, away_record, home_rank, home_team, home_record, venue, city, state, network, start_time, away_flair, home_flair, game_clock, away_score, home_score, boxscore) = game_info
     if game_clock != '':
         away_score, home_score, game_clock = '**' + str(away_score) + '**', '**' + str(home_score) + '**', '- **' + game_clock + '**'
     if away_flair == '':
@@ -54,6 +54,8 @@ def make_thread(game_id, game_info, comment_stream_link = ''):
         thread = thread + home_team
     else:
         thread = thread + home_flair
+    
+    thread = thread + create_boxscore(home_team, away_team, boxscore)
     thread = thread + ' ' + game_clock.upper() + '\n\n\n###NCAA Basketball\n [**^Click ^here ^to ^request ^a ^Game ^Thread**](https://www.reddit.com/r/CollegeBasketball/comments/5o5at9/introducing_ucbbbot_an_easier_way_of_making_game/)\n\n---\n '
     if away_record == '':
         away_record = '--'

--- a/cbbBot.py
+++ b/cbbBot.py
@@ -20,7 +20,7 @@ except:
     quit()
 
 def get_info(game_id):
-    (away_rank, away_team, away_record, home_rank, home_team, home_record, venue, city, state, network, start_time, game_clock, away_score, home_score) = cbbBot_func.espn(game_id)
+    (away_rank, away_team, away_record, home_rank, home_team, home_record, venue, city, state, network, start_time, game_clock, away_score, home_score, boxscore) = cbbBot_func.espn(game_id)
     with open('./data/ranking.txt', 'r') as imp_file:
         lines = imp_file.readlines()
     (teams, rank_names) = cbbBot_func.get_teams()
@@ -39,7 +39,7 @@ def get_info(game_id):
         if rank_names[home_team] in ranking.keys():
             home_rank = str(ranking[rank_names[home_team]])
         home_flair = teams[home_team]
-    return [away_rank, away_team, away_record, home_rank, home_team, home_record, venue, city, state, network, start_time, away_flair, home_flair, game_clock, away_score, home_score]
+    return [away_rank, away_team, away_record, home_rank, home_team, home_record, venue, city, state, network, start_time, away_flair, home_flair, game_clock, away_score, home_score, boxscore]
 
 def make_thread(game_id, game_info, comment_stream_link = ''):
     (away_rank, away_team, away_record, home_rank, home_team, home_record, venue, city, state, network, start_time, away_flair, home_flair, game_clock, away_score, home_score, boxscore) = game_info

--- a/cbbBot_func.py
+++ b/cbbBot_func.py
@@ -116,7 +116,9 @@ def create_boxscore(home_team, away_team, boxscore_data):
         boxscore_string += '\n'
         boxscore_line = [team]
         for stat in game_stats:
-            boxscore_line.append(stats[stat])
+            has_stat = stat in stats.keys()
+            value = stats[stat] if has_stat else ' '
+            boxscore_line.append(value)
         boxscore_string += ' | '.join(boxscore_line)
     
     return boxscore_string

--- a/data/completed_boxscore.json
+++ b/data/completed_boxscore.json
@@ -1,0 +1,1686 @@
+{
+  "teams": [{
+    "team": {
+      "id": "2132",
+      "uid": "s:40~l:41~t:2132",
+      "slug": "cincinnati-bearcats",
+      "location": "Cincinnati",
+      "name": "Bearcats",
+      "abbreviation": "CIN",
+      "displayName": "Cincinnati Bearcats",
+      "shortDisplayName": "Cincinnati",
+      "color": "000000",
+      "alternateColor": "717073",
+      "logo": "https://a.espncdn.com/i/teamlogos/ncaa/500/2132.png"
+    },
+    "statistics": [{
+      "name": "fieldGoalsMade-fieldGoalsAttempted",
+      "displayValue": "23-52",
+      "label": "FG"
+    }, {
+      "name": "fieldGoalPct",
+      "displayValue": "44.2",
+      "abbreviation": "FG%",
+      "label": "Field Goal %"
+    }, {
+      "name": "threePointFieldGoalsMade-threePointFieldGoalsAttempted",
+      "displayValue": "5-17",
+      "label": "3PT"
+    }, {
+      "name": "threePointFieldGoalPct",
+      "displayValue": "29.4",
+      "abbreviation": "3P%",
+      "label": "Three Point %"
+    }, {
+      "name": "freeThrowsMade-freeThrowsAttempted",
+      "displayValue": "19-24",
+      "label": "FT"
+    }, {
+      "name": "freeThrowPct",
+      "displayValue": "79.2",
+      "abbreviation": "FT%",
+      "label": "Free Throw %"
+    }, {
+      "name": "totalRebounds",
+      "displayValue": "41",
+      "abbreviation": "REB",
+      "label": "Rebounds"
+    }, {
+      "name": "offensiveRebounds",
+      "displayValue": "11",
+      "abbreviation": "OR",
+      "label": "Offensive Rebounds"
+    }, {
+      "name": "defensiveRebounds",
+      "displayValue": "30",
+      "abbreviation": "DR",
+      "label": "Defensive Rebounds"
+    }, {
+      "name": "teamRebounds",
+      "displayValue": "0",
+      "abbreviation": "TREB",
+      "label": "Team Rebounds"
+    }, {
+      "name": "assists",
+      "displayValue": "15",
+      "abbreviation": "AST",
+      "label": "Assists"
+    }, {
+      "name": "steals",
+      "displayValue": "3",
+      "abbreviation": "STL",
+      "label": "Steals"
+    }, {
+      "name": "blocks",
+      "displayValue": "1",
+      "abbreviation": "BLK",
+      "label": "Blocks"
+    }, {
+      "name": "turnovers",
+      "displayValue": "19",
+      "abbreviation": "TO",
+      "label": "Turnovers"
+    }, {
+      "name": "teamTurnovers",
+      "displayValue": "0",
+      "abbreviation": "TTO",
+      "label": "Team Turnovers"
+    }, {
+      "name": "totalTurnovers",
+      "displayValue": "19",
+      "abbreviation": "ToTO",
+      "label": "Total Turnovers"
+    }, {
+      "name": "technicalFouls",
+      "displayValue": "5",
+      "abbreviation": "TECH",
+      "label": "Technical Fouls"
+    }, {
+      "name": "totalTechnicalFouls",
+      "displayValue": "5",
+      "abbreviation": "TECH",
+      "label": "Total Technical Fouls"
+    }, {
+      "name": "flagrantFouls",
+      "displayValue": "0",
+      "abbreviation": "FLAG",
+      "label": "Flagrant Fouls"
+    }, {
+      "name": "fouls",
+      "displayValue": "25",
+      "abbreviation": "PF",
+      "label": "Fouls"
+    }, {
+      "name": "largestLead",
+      "displayValue": "7",
+      "abbreviation": "LL",
+      "label": "Largest Lead"
+    }]
+  }, {
+    "team": {
+      "id": "2116",
+      "uid": "s:40~l:41~t:2116",
+      "slug": "ucf-knights",
+      "location": "UCF",
+      "name": "Knights",
+      "abbreviation": "UCF",
+      "displayName": "UCF Knights",
+      "shortDisplayName": "UCF",
+      "color": "000000",
+      "alternateColor": "231f20",
+      "logo": "https://a.espncdn.com/i/teamlogos/ncaa/500/2116.png"
+    },
+    "statistics": [{
+      "name": "fieldGoalsMade-fieldGoalsAttempted",
+      "displayValue": "26-57",
+      "label": "FG"
+    }, {
+      "name": "fieldGoalPct",
+      "displayValue": "45.6",
+      "abbreviation": "FG%",
+      "label": "Field Goal %"
+    }, {
+      "name": "threePointFieldGoalsMade-threePointFieldGoalsAttempted",
+      "displayValue": "9-21",
+      "label": "3PT"
+    }, {
+      "name": "threePointFieldGoalPct",
+      "displayValue": "42.9",
+      "abbreviation": "3P%",
+      "label": "Three Point %"
+    }, {
+      "name": "freeThrowsMade-freeThrowsAttempted",
+      "displayValue": "14-24",
+      "label": "FT"
+    }, {
+      "name": "freeThrowPct",
+      "displayValue": "58.3",
+      "abbreviation": "FT%",
+      "label": "Free Throw %"
+    }, {
+      "name": "totalRebounds",
+      "displayValue": "27",
+      "abbreviation": "REB",
+      "label": "Rebounds"
+    }, {
+      "name": "offensiveRebounds",
+      "displayValue": "6",
+      "abbreviation": "OR",
+      "label": "Offensive Rebounds"
+    }, {
+      "name": "defensiveRebounds",
+      "displayValue": "21",
+      "abbreviation": "DR",
+      "label": "Defensive Rebounds"
+    }, {
+      "name": "teamRebounds",
+      "displayValue": "0",
+      "abbreviation": "TREB",
+      "label": "Team Rebounds"
+    }, {
+      "name": "assists",
+      "displayValue": "8",
+      "abbreviation": "AST",
+      "label": "Assists"
+    }, {
+      "name": "steals",
+      "displayValue": "6",
+      "abbreviation": "STL",
+      "label": "Steals"
+    }, {
+      "name": "blocks",
+      "displayValue": "4",
+      "abbreviation": "BLK",
+      "label": "Blocks"
+    }, {
+      "name": "turnovers",
+      "displayValue": "8",
+      "abbreviation": "TO",
+      "label": "Turnovers"
+    }, {
+      "name": "teamTurnovers",
+      "displayValue": "0",
+      "abbreviation": "TTO",
+      "label": "Team Turnovers"
+    }, {
+      "name": "totalTurnovers",
+      "displayValue": "8",
+      "abbreviation": "ToTO",
+      "label": "Total Turnovers"
+    }, {
+      "name": "technicalFouls",
+      "displayValue": "4",
+      "abbreviation": "TECH",
+      "label": "Technical Fouls"
+    }, {
+      "name": "totalTechnicalFouls",
+      "displayValue": "4",
+      "abbreviation": "TECH",
+      "label": "Total Technical Fouls"
+    }, {
+      "name": "flagrantFouls",
+      "displayValue": "0",
+      "abbreviation": "FLAG",
+      "label": "Flagrant Fouls"
+    }, {
+      "name": "fouls",
+      "displayValue": "22",
+      "abbreviation": "PF",
+      "label": "Fouls"
+    }, {
+      "name": "largestLead",
+      "displayValue": "13",
+      "abbreviation": "LL",
+      "label": "Largest Lead"
+    }]
+  }],
+  "players": [{
+    "team": {
+      "id": "2132",
+      "uid": "s:40~l:41~t:2132",
+      "slug": "cincinnati-bearcats",
+      "location": "Cincinnati",
+      "name": "Bearcats",
+      "abbreviation": "CIN",
+      "displayName": "Cincinnati Bearcats",
+      "shortDisplayName": "Cincinnati",
+      "color": "000000",
+      "alternateColor": "717073",
+      "logo": "https://a.espncdn.com/i/teamlogos/ncaa/500/2132.png"
+    },
+    "statistics": [{
+      "names": ["MIN", "FG", "3PT", "FT", "OREB", "DREB", "REB", "AST", "STL", "BLK", "TO", "PF", "PTS"],
+      "labels": ["MIN", "FG", "3PT", "FT", "OREB", "DREB", "REB", "AST", "STL", "BLK", "TO", "PF", "PTS"],
+      "descriptions": ["Minutes", "Field Goals Made/Attempted", "3-Point Field Goals Made/Attempted", "Free Throws Made/Attempted", "Offensive Rebounds", "Defensive Rebounds", "Rebounds", "Assists", "Steals", "Blocks", "Turnovers", "Personal Fouls", "Points"],
+      "athletes": [{
+        "active": false,
+        "athlete": {
+          "id": "4433192",
+          "uid": "s:40~l:41~a:4433192",
+          "guid": "a610b84c-69a2-3ab4-abce-9dddb1f0b479",
+          "displayName": "Tari Eason",
+          "shortName": "T. Eason",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4433192/tari-eason",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4433192/tari-eason",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4433192/tari-eason",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4433192/tari-eason",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4433192/tari-eason",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4433192/tari-eason",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4433192/tari-eason",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4433192.png",
+            "alt": "Tari Eason"
+          },
+          "jersey": "13",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["10", "1-1", "0-0", "3-4", "1", "3", "4", "1", "0", "0", "3", "5", "5"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4279252",
+          "uid": "s:40~l:41~a:4279252",
+          "guid": "c98d5b76be42bd4d29f23f0006174acf",
+          "displayName": "Chris Vogt",
+          "shortName": "C. Vogt",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4279252/chris-vogt",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4279252/chris-vogt",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4279252/chris-vogt",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4279252/chris-vogt",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4279252/chris-vogt",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4279252/chris-vogt",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4279252/chris-vogt",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4279252.png",
+            "alt": "Chris Vogt"
+          },
+          "jersey": "33",
+          "position": {
+            "name": "Center",
+            "displayName": "Center",
+            "abbreviation": "C"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["19", "0-1", "0-0", "0-0", "0", "2", "2", "2", "0", "1", "1", "3", "0"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4431831",
+          "uid": "s:40~l:41~a:4431831",
+          "guid": "c1233e1a-6e48-3fac-a303-c339c26b1686",
+          "displayName": "Mika Adams-Woods",
+          "shortName": "M. Adams-Woods",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4431831/mika-adams-woods",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4431831/mika-adams-woods",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4431831/mika-adams-woods",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4431831/mika-adams-woods",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4431831/mika-adams-woods",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4431831/mika-adams-woods",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4431831/mika-adams-woods",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4431831.png",
+            "alt": "Mika Adams-Woods"
+          },
+          "jersey": "23",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["29", "3-6", "1-4", "2-2", "3", "0", "3", "1", "0", "0", "3", "3", "9"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4397202",
+          "uid": "s:40~l:41~a:4397202",
+          "guid": "b9fd1243d7f0a6b7e97691e71e8d6161",
+          "displayName": "David DeJulius",
+          "shortName": "D. DeJulius",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4397202/david-dejulius",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4397202/david-dejulius",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4397202/david-dejulius",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4397202/david-dejulius",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4397202/david-dejulius",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4397202/david-dejulius",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4397202/david-dejulius",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4397202.png",
+            "alt": "David DeJulius"
+          },
+          "jersey": "0",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["27", "4-8", "0-3", "1-1", "1", "2", "3", "5", "0", "0", "4", "2", "9"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4278217",
+          "uid": "s:40~l:41~a:4278217",
+          "guid": "01625c045205aeb876d20440b7f1b124",
+          "displayName": "Keith Williams",
+          "shortName": "K. Williams",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4278217/keith-williams",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4278217/keith-williams",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4278217/keith-williams",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4278217/keith-williams",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4278217/keith-williams",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4278217/keith-williams",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4278217/keith-williams",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4278217.png",
+            "alt": "Keith Williams"
+          },
+          "jersey": "2",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["29", "6-17", "2-3", "5-5", "2", "8", "10", "1", "1", "0", "3", "3", "19"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4066395",
+          "uid": "s:40~l:41~a:4066395",
+          "guid": "96299a84f74c1c0cdb7688d330b033a0",
+          "displayName": "Rapolas Ivanauskas",
+          "shortName": "R. Ivanauskas",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4066395/rapolas-ivanauskas",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4066395/rapolas-ivanauskas",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4066395/rapolas-ivanauskas",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4066395/rapolas-ivanauskas",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4066395/rapolas-ivanauskas",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4066395/rapolas-ivanauskas",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4066395/rapolas-ivanauskas",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4066395.png",
+            "alt": "Rapolas Ivanauskas"
+          },
+          "jersey": "25",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["18", "2-5", "0-2", "0-1", "0", "3", "3", "0", "1", "0", "0", "4", "4"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4592899",
+          "uid": "s:40~l:41~a:4592899",
+          "guid": "cf51ce56-d716-3164-9926-707d7a855923",
+          "displayName": "Zach Harvey",
+          "shortName": "Z. Harvey",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4592899/zach-harvey",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4592899/zach-harvey",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4592899/zach-harvey",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4592899/zach-harvey",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4592899/zach-harvey",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4592899/zach-harvey",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4592899/zach-harvey",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4592899.png",
+            "alt": "Zach Harvey"
+          },
+          "jersey": "1",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["24", "5-6", "2-3", "3-4", "1", "2", "3", "0", "0", "0", "0", "1", "15"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4592898",
+          "uid": "s:40~l:41~a:4592898",
+          "guid": "1abc35f9-c6d2-3276-89e8-fd1bb25540f4",
+          "displayName": "Jeremiah Davenport",
+          "shortName": "J. Davenport",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4592898/jeremiah-davenport",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4592898/jeremiah-davenport",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4592898/jeremiah-davenport",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4592898/jeremiah-davenport",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4592898/jeremiah-davenport",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4592898/jeremiah-davenport",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4592898/jeremiah-davenport",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4592898.png",
+            "alt": "Jeremiah Davenport"
+          },
+          "jersey": "24",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["24", "2-5", "0-1", "3-5", "1", "5", "6", "2", "0", "0", "2", "1", "7"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4432403",
+          "uid": "s:40~l:41~a:4432403",
+          "guid": "7aa30e13-d9d5-3b1a-92e7-7ac7ea068e77",
+          "displayName": "Mike Saunders",
+          "shortName": "M. Saunders",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4432403/mike-saunders",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4432403/mike-saunders",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4432403/mike-saunders",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4432403/mike-saunders",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4432403/mike-saunders",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4432403/mike-saunders",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4432403/mike-saunders",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4432403.png",
+            "alt": "Mike Saunders"
+          },
+          "jersey": "3",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["20", "0-3", "0-1", "2-2", "1", "3", "4", "3", "1", "0", "3", "2", "2"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4701192",
+          "uid": "s:40~l:41~a:4701192",
+          "guid": "c3be0103-5dae-3077-b687-3606b571a248",
+          "displayName": "Viktor Lakhin",
+          "shortName": "V. Lakhin",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4701192/viktor-lakhin",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4701192/viktor-lakhin",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4701192/viktor-lakhin",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4701192/viktor-lakhin",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4701192/viktor-lakhin",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4701192/viktor-lakhin",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4701192.png",
+            "alt": "Viktor Lakhin"
+          },
+          "jersey": "30",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4598638",
+          "uid": "s:40~l:41~a:4598638",
+          "guid": "98c102aa-4f6f-311c-a579-c228cb21d902",
+          "displayName": "Adam Cook",
+          "shortName": "A. Cook",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4598638/adam-cook",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4598638/adam-cook",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4598638/adam-cook",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4598638/adam-cook",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4598638/adam-cook",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4598638/adam-cook",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4598638.png",
+            "alt": "Adam Cook"
+          },
+          "jersey": "44",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4592900",
+          "uid": "s:40~l:41~a:4592900",
+          "guid": "2e541104-4999-3693-8576-9a8c038ffc1a",
+          "displayName": "Rob Banks",
+          "shortName": "R. Banks",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4592900/rob-banks",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4592900/rob-banks",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4592900/rob-banks",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4592900/rob-banks",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4592900/rob-banks",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4592900/rob-banks",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4592900.png",
+            "alt": "Rob Banks"
+          },
+          "jersey": "43",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4278219",
+          "uid": "s:40~l:41~a:4278219",
+          "guid": "f95bfa0edfd3d4e6cad369b91486f178",
+          "displayName": "Mamoudou Diarra",
+          "shortName": "M. Diarra",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4278219/mamoudou-diarra",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4278219/mamoudou-diarra",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4278219/mamoudou-diarra",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4278219/mamoudou-diarra",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4278219/mamoudou-diarra",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4278219/mamoudou-diarra",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4278219/mamoudou-diarra",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4278219.png",
+            "alt": "Mamoudou Diarra"
+          },
+          "jersey": "20",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4581506",
+          "uid": "s:40~l:41~a:4581506",
+          "guid": "83b806d0-f835-3b40-a1b9-d31671ddd6a7",
+          "displayName": "Mason Madsen",
+          "shortName": "M. Madsen",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4581506/mason-madsen",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4581506/mason-madsen",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4581506/mason-madsen",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4581506/mason-madsen",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4581506/mason-madsen",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4581506/mason-madsen",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4581506.png",
+            "alt": "Mason Madsen"
+          },
+          "jersey": "45",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4432753",
+          "uid": "s:40~l:41~a:4432753",
+          "guid": "eb02da56-068d-39e4-a76c-fb9c4fa1da48",
+          "displayName": "Gabe Madsen",
+          "shortName": "G. Madsen",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4432753/gabe-madsen",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4432753/gabe-madsen",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4432753/gabe-madsen",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4432753/gabe-madsen",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4432753/gabe-madsen",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4432753/gabe-madsen",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4432753/gabe-madsen",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4432753.png",
+            "alt": "Gabe Madsen"
+          },
+          "jersey": "55",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4278221",
+          "uid": "s:40~l:41~a:4278221",
+          "guid": "97a3913d24e3ab346f00de52c15a4fac",
+          "displayName": "Sam Martin",
+          "shortName": "S. Martin",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4278221/sam-martin",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4278221/sam-martin",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4278221/sam-martin",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4278221/sam-martin",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4278221/sam-martin",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4278221/sam-martin",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4278221.png",
+            "alt": "Sam Martin"
+          },
+          "jersey": "31",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }],
+      "totals": ["", "23-52", "5-17", "19-24", "11", "30", "41", "15", "3", "1", "19", "25", "70"]
+    }]
+  }, {
+    "team": {
+      "id": "2116",
+      "uid": "s:40~l:41~t:2116",
+      "slug": "ucf-knights",
+      "location": "UCF",
+      "name": "Knights",
+      "abbreviation": "UCF",
+      "displayName": "UCF Knights",
+      "shortDisplayName": "UCF",
+      "color": "000000",
+      "alternateColor": "231f20",
+      "logo": "https://a.espncdn.com/i/teamlogos/ncaa/500/2116.png"
+    },
+    "statistics": [{
+      "names": ["MIN", "FG", "3PT", "FT", "OREB", "DREB", "REB", "AST", "STL", "BLK", "TO", "PF", "PTS"],
+      "labels": ["MIN", "FG", "3PT", "FT", "OREB", "DREB", "REB", "AST", "STL", "BLK", "TO", "PF", "PTS"],
+      "descriptions": ["Minutes", "Field Goals Made/Attempted", "3-Point Field Goals Made/Attempted", "Free Throws Made/Attempted", "Offensive Rebounds", "Defensive Rebounds", "Rebounds", "Assists", "Steals", "Blocks", "Turnovers", "Personal Fouls", "Points"],
+      "athletes": [{
+        "active": false,
+        "athlete": {
+          "id": "4433527",
+          "uid": "s:40~l:41~a:4433527",
+          "guid": "5fdd2fc4-8a20-3aec-9839-5a95f86c022c",
+          "displayName": "Isaiah Adams",
+          "shortName": "I. Adams",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4433527/isaiah-adams",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4433527/isaiah-adams",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4433527/isaiah-adams",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4433527/isaiah-adams",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4433527/isaiah-adams",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4433527/isaiah-adams",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4433527/isaiah-adams",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4433527.png",
+            "alt": "Isaiah Adams"
+          },
+          "jersey": "3",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["25", "6-8", "1-2", "2-6", "0", "4", "4", "0", "2", "0", "1", "4", "15"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4278418",
+          "uid": "s:40~l:41~a:4278418",
+          "guid": "46b363bcc9e7c07829a8266bac4d778b",
+          "displayName": "Sean Mobley",
+          "shortName": "S. Mobley",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4278418/sean-mobley",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4278418/sean-mobley",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4278418/sean-mobley",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4278418/sean-mobley",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4278418/sean-mobley",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4278418/sean-mobley",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4278418/sean-mobley",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4278418.png",
+            "alt": "Sean Mobley"
+          },
+          "jersey": "20",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["22", "1-3", "0-1", "0-1", "1", "1", "2", "3", "1", "0", "1", "4", "2"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4593839",
+          "uid": "s:40~l:41~a:4593839",
+          "guid": "7ef9f127-52d4-34cb-832d-ac60f7dca459",
+          "displayName": "Darin Green Jr.",
+          "shortName": "D. Green Jr.",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4593839/darin-green-jr",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4593839/darin-green-jr",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4593839/darin-green-jr",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4593839/darin-green-jr",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4593839/darin-green-jr",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4593839/darin-green-jr",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4593839/darin-green-jr",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4593839.png",
+            "alt": "Darin Green Jr."
+          },
+          "jersey": "22",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["33", "5-9", "2-4", "0-0", "0", "1", "1", "0", "0", "0", "1", "2", "12"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4396917",
+          "uid": "s:40~l:41~a:4396917",
+          "guid": "4b1fc45531f751fc6ad33ed534559aea",
+          "displayName": "Brandon Mahan",
+          "shortName": "B. Mahan",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4396917/brandon-mahan",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4396917/brandon-mahan",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4396917/brandon-mahan",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4396917/brandon-mahan",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4396917/brandon-mahan",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4396917/brandon-mahan",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4396917/brandon-mahan",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4396917.png",
+            "alt": "Brandon Mahan"
+          },
+          "jersey": "13",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["38", "8-13", "5-7", "4-5", "4", "6", "10", "1", "0", "0", "1", "1", "25"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4396670",
+          "uid": "s:40~l:41~a:4396670",
+          "guid": "fc923962cff8d1b73ee4f4c1fd452984",
+          "displayName": "Dre Fuller Jr.",
+          "shortName": "D. Fuller Jr.",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4396670/dre-fuller-jr",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4396670/dre-fuller-jr",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4396670/dre-fuller-jr",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4396670/dre-fuller-jr",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4396670/dre-fuller-jr",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4396670/dre-fuller-jr",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4396670/dre-fuller-jr",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4396670.png",
+            "alt": "Dre Fuller Jr."
+          },
+          "jersey": "24",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": true,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["34", "3-7", "0-1", "3-4", "0", "2", "2", "3", "3", "0", "4", "4", "9"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4592403",
+          "uid": "s:40~l:41~a:4592403",
+          "guid": "7e539058-00f7-3312-9f6b-34bca0140a74",
+          "displayName": "C.J. Walker",
+          "shortName": "C.J. Walker",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4592403/cj-walker",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4592403/cj-walker",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4592403/cj-walker",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4592403/cj-walker",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4592403/cj-walker",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4592403/cj-walker",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4592403/cj-walker",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4592403.png",
+            "alt": "C.J. Walker"
+          },
+          "jersey": "21",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["21", "2-6", "0-0", "3-6", "0", "2", "2", "1", "0", "4", "0", "3", "7"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4278109",
+          "uid": "s:40~l:41~a:4278109",
+          "guid": "24c314bf69f4b1a4ddede75df0252e75",
+          "displayName": "Ibrahim Famouke Doumbia",
+          "shortName": "I. Doumbia",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4278109/ibrahim-famouke-doumbia",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4278109/ibrahim-famouke-doumbia",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4278109/ibrahim-famouke-doumbia",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4278109/ibrahim-famouke-doumbia",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4278109/ibrahim-famouke-doumbia",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4278109/ibrahim-famouke-doumbia",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4278109/ibrahim-famouke-doumbia",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4278109.png",
+            "alt": "Ibrahim Famouke Doumbia"
+          },
+          "jersey": "14",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["2", "0-0", "0-0", "0-0", "1", "0", "1", "0", "0", "0", "0", "2", "0"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4277878",
+          "uid": "s:40~l:41~a:4277878",
+          "guid": "17d3a3a1d713bafdb637ca1a514e2f50",
+          "displayName": "Darius Perry",
+          "shortName": "D. Perry",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4277878/darius-perry",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4277878/darius-perry",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4277878/darius-perry",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4277878/darius-perry",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4277878/darius-perry",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4277878/darius-perry",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4277878/darius-perry",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4277878.png",
+            "alt": "Darius Perry"
+          },
+          "jersey": "2",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": false,
+        "ejected": false,
+        "stats": ["25", "1-11", "1-6", "2-2", "0", "2", "2", "0", "0", "0", "0", "2", "5"]
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4432407",
+          "uid": "s:40~l:41~a:4432407",
+          "guid": "78794c62-db15-3355-b45c-ba9ebecca2b5",
+          "displayName": "Jamille Reynolds",
+          "shortName": "J. Reynolds",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4432407/jamille-reynolds",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4432407/jamille-reynolds",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4432407/jamille-reynolds",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4432407/jamille-reynolds",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4432407/jamille-reynolds",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4432407/jamille-reynolds",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4432407/jamille-reynolds",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4432407.png",
+            "alt": "Jamille Reynolds"
+          },
+          "jersey": "4",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4396674",
+          "uid": "s:40~l:41~a:4396674",
+          "guid": "f702fc8079d556405cef381c0745217e",
+          "displayName": "Ryan Anders",
+          "shortName": "R. Anders",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4396674/ryan-anders",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4396674/ryan-anders",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4396674/ryan-anders",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4396674/ryan-anders",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4396674/ryan-anders",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4396674/ryan-anders",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4396674.png",
+            "alt": "Ryan Anders"
+          },
+          "jersey": "25",
+          "position": {
+            "name": "Forward",
+            "displayName": "Forward",
+            "abbreviation": "F"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4593840",
+          "uid": "s:40~l:41~a:4593840",
+          "guid": "10d22cef-c4c1-3e9c-aac1-262d29c24d5e",
+          "displayName": "Moses Bol",
+          "shortName": "M. Bol",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4593840/moses-bol",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4593840/moses-bol",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4593840/moses-bol",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4593840/moses-bol",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4593840/moses-bol",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4593840/moses-bol",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4593840.png",
+            "alt": "Moses Bol"
+          },
+          "jersey": "33",
+          "position": {
+            "name": "Center",
+            "displayName": "Center",
+            "abbreviation": "C"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4278461",
+          "uid": "s:40~l:41~a:4278461",
+          "guid": "013cb6fa3308c7e579e2ae124ef56422",
+          "displayName": "Avery Diggs",
+          "shortName": "A. Diggs",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4278461/avery-diggs",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4278461/avery-diggs",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4278461/avery-diggs",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4278461/avery-diggs",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4278461/avery-diggs",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4278461/avery-diggs",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4278461/avery-diggs",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4278461.png",
+            "alt": "Avery Diggs"
+          },
+          "jersey": "5",
+          "position": {
+            "name": "Center",
+            "displayName": "Center",
+            "abbreviation": "C"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4701191",
+          "uid": "s:40~l:41~a:4701191",
+          "guid": "cf89c2a4-3611-3c5b-9142-fa94045a15c4",
+          "displayName": "Isaac Ward",
+          "shortName": "I. Ward",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4701191/isaac-ward",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4701191/isaac-ward",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4701191/isaac-ward",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4701191/isaac-ward",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4701191/isaac-ward",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4701191/isaac-ward",
+            "text": "Overview"
+          }],
+          "jersey": "15",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4432894",
+          "uid": "s:40~l:41~a:4432894",
+          "guid": "b60fe7d0-70ee-309a-8b1e-63b41a290d35",
+          "displayName": "Tony Johnson Jr.",
+          "shortName": "T. Johnson Jr.",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4432894/tony-johnson-jr",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/stats/_/id/4432894/tony-johnson-jr",
+            "text": "Stats"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4432894/tony-johnson-jr",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4432894/tony-johnson-jr",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4432894/tony-johnson-jr",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4432894/tony-johnson-jr",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4432894/tony-johnson-jr",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4432894.png",
+            "alt": "Tony Johnson Jr."
+          },
+          "jersey": "1",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4396672",
+          "uid": "s:40~l:41~a:4396672",
+          "guid": "9d62dac10d133112f06d06a797489ce5",
+          "displayName": "Levy Renaud",
+          "shortName": "L. Renaud",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4396672/levy-renaud",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4396672/levy-renaud",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4396672/levy-renaud",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4396672/levy-renaud",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4396672/levy-renaud",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4396672/levy-renaud",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4396672.png",
+            "alt": "Levy Renaud"
+          },
+          "jersey": "10",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }, {
+        "active": false,
+        "athlete": {
+          "id": "4396671",
+          "uid": "s:40~l:41~a:4396671",
+          "guid": "1a92aaa9a247e60ed6991a74497f13ff",
+          "displayName": "Xavier Grant",
+          "shortName": "X. Grant",
+          "links": [{
+            "href": "https://www.espn.com/mens-college-basketball/player/_/id/4396671/xavier-grant",
+            "text": "Player Card"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/splits/_/id/4396671/xavier-grant",
+            "text": "Splits"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/gamelog/_/id/4396671/xavier-grant",
+            "text": "Game Log"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/news/_/id/4396671/xavier-grant",
+            "text": "News"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/bio/_/id/4396671/xavier-grant",
+            "text": "Bio"
+          }, {
+            "href": "http://www.espn.com/mens-college-basketball/player/_/id/4396671/xavier-grant",
+            "text": "Overview"
+          }],
+          "headshot": {
+            "href": "https://a.espncdn.com/i/headshots/mens-college-basketball/players/full/4396671.png",
+            "alt": "Xavier Grant"
+          },
+          "jersey": "11",
+          "position": {
+            "name": "Guard",
+            "displayName": "Guard",
+            "abbreviation": "G"
+          }
+        },
+        "starter": false,
+        "didNotPlay": true,
+        "ejected": false,
+        "stats": []
+      }],
+      "totals": ["", "26-57", "9-21", "14-24", "6", "21", "27", "8", "6", "4", "8", "22", "75"]
+    }]
+  }]
+}

--- a/data/unplayed_boxscore.json
+++ b/data/unplayed_boxscore.json
@@ -1,0 +1,142 @@
+{
+  "teams": [{
+    "team": {
+      "id": "91",
+      "uid": "s:40~l:41~t:91",
+      "slug": "bellarmine-knights",
+      "location": "Bellarmine",
+      "name": "Knights",
+      "abbreviation": "BELL",
+      "displayName": "Bellarmine Knights",
+      "shortDisplayName": "Bellarmine",
+      "color": "000000",
+      "logo": "https://a.espncdn.com/i/teamlogos/ncaa/500/91.png"
+    },
+    "statistics": [{
+      "name": "streak",
+      "displayValue": "L1",
+      "abbreviation": "STRK",
+      "label": "Streak"
+    }, {
+      "name": "avgPoints",
+      "displayValue": "68.7",
+      "abbreviation": "PTS",
+      "label": "Points Per Game"
+    }, {
+      "name": "fieldGoalPct",
+      "displayValue": "47.6",
+      "abbreviation": "FG%",
+      "label": "Field Goal %"
+    }, {
+      "name": "threePointFieldGoalPct",
+      "displayValue": "39.0",
+      "abbreviation": "3P%",
+      "label": "Three Point %"
+    }, {
+      "name": "avgRebounds",
+      "displayValue": "32.0",
+      "abbreviation": "REB",
+      "label": "Rebounds Per Game"
+    }, {
+      "name": "avgAssists",
+      "displayValue": "16.3",
+      "abbreviation": "AST",
+      "label": "Assists Per Game"
+    }, {
+      "name": "avgBlocks",
+      "displayValue": "0.7",
+      "abbreviation": "BLK",
+      "label": "Blocks Per Game"
+    }, {
+      "name": "avgSteals",
+      "displayValue": "5.0",
+      "abbreviation": "STL",
+      "label": "Steals Per Game"
+    }, {
+      "name": "avgTeamTurnovers",
+      "displayValue": "0.7",
+      "abbreviation": "TTO",
+      "label": "Team Turnovers Per Game"
+    }, {
+      "name": "avgTotalTurnovers",
+      "displayValue": "14.7",
+      "abbreviation": "ToTO",
+      "label": "Total Turnovers Per Game"
+    }, {
+      "name": "avgPointsAgainst",
+      "displayValue": "72.0",
+      "abbreviation": "PA",
+      "label": "Points Against"
+    }]
+  }, {
+    "team": {
+      "id": "87",
+      "uid": "s:40~l:41~t:87",
+      "slug": "notre-dame-fighting-irish",
+      "location": "Notre Dame",
+      "name": "Fighting Irish",
+      "abbreviation": "ND",
+      "displayName": "Notre Dame Fighting Irish",
+      "shortDisplayName": "Notre Dame",
+      "color": "00122b",
+      "alternateColor": "ae9142",
+      "logo": "https://a.espncdn.com/i/teamlogos/ncaa/500/87.png"
+    },
+    "statistics": [{
+      "name": "streak",
+      "displayValue": "L2",
+      "abbreviation": "STRK",
+      "label": "Streak"
+    }, {
+      "name": "avgPoints",
+      "displayValue": "73.3",
+      "abbreviation": "PTS",
+      "label": "Points Per Game"
+    }, {
+      "name": "fieldGoalPct",
+      "displayValue": "43.6",
+      "abbreviation": "FG%",
+      "label": "Field Goal %"
+    }, {
+      "name": "threePointFieldGoalPct",
+      "displayValue": "41.1",
+      "abbreviation": "3P%",
+      "label": "Three Point %"
+    }, {
+      "name": "avgRebounds",
+      "displayValue": "33.5",
+      "abbreviation": "REB",
+      "label": "Rebounds Per Game"
+    }, {
+      "name": "avgAssists",
+      "displayValue": "14.8",
+      "abbreviation": "AST",
+      "label": "Assists Per Game"
+    }, {
+      "name": "avgBlocks",
+      "displayValue": "3.8",
+      "abbreviation": "BLK",
+      "label": "Blocks Per Game"
+    }, {
+      "name": "avgSteals",
+      "displayValue": "3.7",
+      "abbreviation": "STL",
+      "label": "Steals Per Game"
+    }, {
+      "name": "avgTeamTurnovers",
+      "displayValue": "0.5",
+      "abbreviation": "TTO",
+      "label": "Team Turnovers Per Game"
+    }, {
+      "name": "avgTotalTurnovers",
+      "displayValue": "11.8",
+      "abbreviation": "ToTO",
+      "label": "Total Turnovers Per Game"
+    }, {
+      "name": "avgPointsAgainst",
+      "displayValue": "77.7",
+      "abbreviation": "PA",
+      "label": "Points Against"
+    }]
+  }]
+}

--- a/test.py
+++ b/test.py
@@ -1,0 +1,19 @@
+import unittest
+import json
+from cbbBot_func import create_boxscore
+
+class TestStringMethods(unittest.TestCase):
+    def test_pregame(self):
+        boxscore_string = '\n\nTeam | Streak | Points Per Game | Field Goal % | Three Point % | Rebounds Per Game | Assists Per Game | Blocks Per Game | Steals Per Game | Total Turnovers Per Game | Points Against\n----|----|----|----|----|----|----|----|----|----|----|\nBellarmine | L1 | 68.7 | 47.6 | 39.0 | 32.0 | 16.3 | 0.7 | 5.0 | 14.7 | 72.0\nNotre Dame | L2 | 73.3 | 43.6 | 41.1 | 33.5 | 14.8 | 3.8 | 3.7 | 11.8 | 77.7'
+        with open('data/unplayed_boxscore.json') as f:
+            data = json.load(f)
+            self.assertEqual(create_boxscore('Bellarmine', 'Notre Dame', data), boxscore_string)
+
+    def test_ingame(self):
+        boxscore_string = '\n\nTeam | FG | Field Goal % | 3PT | Three Point % | FT | Free Throw % | Rebounds | Offensive Rebounds | Defensive Rebounds | Assists | Steals | Blocks | Turnovers | Technical Fouls | Flagrant Fouls | Fouls | Largest Lead\n----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|----|\nUCF | 26-57 | 45.6 | 9-21 | 42.9 | 14-24 | 58.3 | 27 | 6 | 21 | 8 | 6 | 4 | 8 | 4 | 0 | 22 | 13\nCincinnati | 23-52 | 44.2 | 5-17 | 29.4 | 19-24 | 79.2 | 41 | 11 | 30 | 15 | 3 | 1 | 19 | 5 | 0 | 25 | 7'
+        with open('data/completed_boxscore.json') as f:
+            data = json.load(f)
+            self.assertEqual(create_boxscore('UCF', 'Cincinnati', data), boxscore_string)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Had some time and decided to go through and add the boxscore. Please let me know if there's anything you'd like to see changed.

Here's an example of what it might look like: https://www.reddit.com/r/FanStatsCss/comments/kixa8y/game_thread_example/?

I'm not sure if there's a better way to show it or if some stats need to get dropped.